### PR TITLE
Fix Linux Build (#9)

### DIFF
--- a/FitdLib/config.h
+++ b/FitdLib/config.h
@@ -59,11 +59,11 @@ typedef int32_t s32;
 #else
 typedef unsigned char u8;
 typedef unsigned short int u16;
-typedef unsigned long int u32;
+typedef unsigned int u32;
 
 typedef signed char s8;
 typedef signed short int s16;
-typedef signed long int s32;
+typedef signed int s32;
 #endif
 
 #include <stdlib.h>


### PR DESCRIPTION
Fixes #9 

Changes `s32` & `u32` to be typed as `signed int` & `unsigned int` instead of  `signed long int` & `unsigned long int`, as this resolves to 64 bits on x64 Linux & 32 bits on Windows, while `signed int` & `unsigned int` resolve to 32 bits on Windows & x64 Linux.

This change has been tested to work on Windows & x64 Linux.